### PR TITLE
feat : relationship request model feature improverments

### DIFF
--- a/src/pipeline/extract.py
+++ b/src/pipeline/extract.py
@@ -14,6 +14,7 @@ class SummaryContext:
     issues: List[str]
     friend_alias: Optional[str]
     tone: str
+    context_hint: Optional[str] = None
     month_text: str = ""
     entries_count: int = 0
 
@@ -26,6 +27,7 @@ class SolutionContext:
     friend_alias: Optional[str]
     goal: str
     tone: str
+    context_hint: Optional[str] = None
     summary: Optional[Dict[str, Any]] = None
     month_text: str = ""
     entries_count: int = 0
@@ -93,6 +95,7 @@ def extract_summary(req: FriendSummaryRequest) -> SummaryContext:
     return SummaryContext(
         friend_alias=req.friend_alias,
         tone=req.tone,
+        context_hint=req.context_hint,
         month_text=month_text,
         situation=situation,
         feelings=feelings,
@@ -109,6 +112,7 @@ def extract_solution(req: FriendSolutionRequest) -> SolutionContext:
         friend_alias=req.friend_alias,
         goal=req.goal,
         tone=req.tone,
+        context_hint=req.context_hint,
         month_text=month_text,
         situation=situation,
         feelings=feelings,

--- a/src/prompts/friend_solution_v1.md
+++ b/src/prompts/friend_solution_v1.md
@@ -19,7 +19,10 @@
 
 # 입력(JSON 문자열로 제공됨)
 
-- text: 원문
+- month_text: 한 달치 기록을 합친 원문(각 줄에 날짜/텍스트/태그가 포함될 수 있음)
+- entries_count: 기록 개수
+- situation: month_text를 압축한 1~2문장 요약
+- feelings/needs/issues: 키워드 기반 힌트 리스트
 - goal: understand|resolve|distance|reconnect|other
 - tone: warm|neutral|direct
 - friend_alias(선택), context_hint(선택)
@@ -31,6 +34,7 @@
 "version": "v1-friend-solution",
 "goal": "string",
 "top_strategy": "string",
+"direction_suggestion": "string",
 "actions": [
 {
 "title": "string",
@@ -51,8 +55,12 @@
 
 # 작성 가이드
 
-- top_strategy: 핵심 전략 한 줄(예: "부담을 최소화한 감정 공유 + 기대치 조율")
-- actions: 3개 권장(낮은 부담→대화→거리두기/재정의)
-- message_templates: 톤에 맞춰 말투 조절(1~3문장)
+- context_hint/summary가 있으면 핵심 근거로 활용한다. (예: 만남 빈도/만족도/감정 반복/선물 주고받음 균형 등)
+- 근거가 없는 숫자/기간 단정은 피한다. 필요한 경우 "~일 가능성이 있어요"로 완곡하게 쓴다.
+- top_strategy: 핵심 전략 한 줄(예: "부담을 최소화한 감정 공유 + 기대치 조율" 또는 "1~2개월 거리두기 후 재정산 권장")
+- direction_suggestion: 화면 하단에 노출할 '관계 방향성 제안' 한 줄(기간/행동 요약)
+- actions: 3개 권장(낮은 부담→대화→거리두기/재정의), 각 description은 2~3문장으로 충분히 길게 쓴다.
+- message_templates: 톤에 맞춰 말투 조절(2~4문장), 충분히 구체적으로 작성한다.
+- situation은 400자 이내의 간단한 "상황 설명/리뷰" 문장으로 작성한다.
 - risks: 부작용/오해 가능성 2~4개
 - if_no_change: 반복되면 어떻게 할지 플랜B 2~4개

--- a/src/prompts/friend_summary_v1.md
+++ b/src/prompts/friend_summary_v1.md
@@ -19,7 +19,10 @@
 
 # 입력(JSON 문자열로 제공됨)
 
-- text: 사용자가 작성한 친구 관계 생각/상황(원문)
+- month_text: 한 달치 기록을 합친 원문(각 줄에 날짜/텍스트/태그가 포함될 수 있음)
+- entries_count: 기록 개수
+- situation: month_text를 압축한 1~2문장 요약
+- feelings/needs/issues: 키워드 기반 힌트 리스트
 - tone: warm|neutral|direct
 - friend_alias(선택), context_hint(선택)
 
@@ -29,6 +32,14 @@
 "version": "v1-friend-summary",
 "one_line_summary": "string",
 "situation_summary": "string",
+"period_label": "string",
+"relationship_status_percent": 0,
+"relationship_status_label": "string",
+"meeting_continuity": "string",
+"post_meeting_satisfaction": "string",
+"emotion_pattern": "string",
+"gift_balance": "string",
+"initiative_balance": "string",
 "facts": ["string"],
 "my_interpretations": ["string"],
 "feelings": ["string"],
@@ -39,8 +50,18 @@
 
 # 작성 가이드
 
+- context_hint가 있으면 핵심 근거로 활용한다. (예: 만남 빈도/만족도/감정 반복/선물 주고받음 균형 등)
+- 근거가 없는 숫자/기간 단정은 피한다. 필요한 경우 "~일 가능성이 있어요"로 완곡하게 쓴다.
 - one_line_summary: 1문장, 가장 핵심만
 - situation_summary: 사실 중심 2~4문장
+- period_label: "최근 3개월 기준"처럼 요약 기준을 짧게 표기
+- relationship_status_percent: 0~100 사이 숫자(관계 상태 게이지)
+- relationship_status_label: 긍정적/보통/부정적 같은 한 단어
+- meeting_continuity: 만남이 이어지는지/빈도를 짧게 요약
+- post_meeting_satisfaction: 만남 이후 만족도 수준을 짧게 요약
+- emotion_pattern: 반복되는 감정을 짧게 요약
+- gift_balance: 선물/호의 주고받음의 균형을 짧게 요약
+- initiative_balance: 누가 먼저 연락/제공을 더 많이 하는지 요약
 - facts: 관찰 가능한 사건/상황 (3~7개 권장)
 - my_interpretations: 내 해석/생각을 "나는 ~라고 느낀다/생각한다" 관점으로 (2~6개 권장)
 - feelings: 감정 단어 2~5개

--- a/src/prompts/output_schemas.json
+++ b/src/prompts/output_schemas.json
@@ -1,6 +1,14 @@
 {
   "version": "v1-friend",
   "summary": "string",
+  "period_label": "string",
+  "relationship_status_percent": 0,
+  "relationship_status_label": "string",
+  "meeting_continuity": "string",
+  "post_meeting_satisfaction": "string",
+  "emotion_pattern": "string",
+  "gift_balance": "string",
+  "initiative_balance": "string",
   "feelings": ["string"],
   "needs": ["string"],
   "possible_interpretations": ["string"],
@@ -18,5 +26,6 @@
       "text": "string"
     }
   ],
-  "cautions": ["string"]
+  "cautions": ["string"],
+  "direction_suggestion": "string"
 }

--- a/src/schemas/relationship.py
+++ b/src/schemas/relationship.py
@@ -38,6 +38,14 @@ class FriendSummaryResponse(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     one_line_summary: str = Field(..., min_length=5, max_length=120, description="한 줄 핵심")
     situation_summary: str = Field(..., min_length=10, max_length=800, description="상황 요약(사실 중심)")
+    period_label: str = Field(default="최근 3개월 기준", min_length=2, max_length=40, description="요약 기준 기간 라벨")
+    relationship_status_percent: int = Field(default=50, ge=0, le=100, description="관계 상태 게이지(0~100)")
+    relationship_status_label: str = Field(default="보통", min_length=1, max_length=20, description="관계 상태 라벨(예: 긍정적/보통/부정적)")
+    meeting_continuity: str = Field(default="", max_length=60, description="만남 지속/빈도 요약(짧은 문장)")
+    post_meeting_satisfaction: str = Field(default="", max_length=60, description="만남 이후 만족도 요약(짧은 문장)")
+    emotion_pattern: str = Field(default="", max_length=80, description="감정 패턴 요약(짧은 문장)")
+    gift_balance: str = Field(default="", max_length=80, description="선물/호의 주고받음 균형 요약")
+    initiative_balance: str = Field(default="", max_length=80, description="먼저 연락/제안한 쪽 요약")
     facts: List[str] = Field(default_factory=list, description="관찰 가능한 사실/사건")
     my_interpretations: List[str] = Field(default_factory=list, description="내 해석/생각(단정X, 내 관점)")
     feelings: List[str] = Field(default_factory=list, description="감정 단어")
@@ -50,14 +58,14 @@ class FriendSummaryResponse(BaseModel):
 class ActionItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
     title: str = Field(..., min_length=2, max_length=60)
-    description: str = Field(..., min_length=5, max_length=500)
+    description: str = Field(..., min_length=5, max_length=800)
     intensity: Literal["low", "medium", "high"] = Field(default="low")
     why_this: Optional[str] = Field(default=None, max_length=300)
 
 class MessageTemplate(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    situation: str = Field(..., min_length=2, max_length=40)
-    text: str = Field(..., min_length=5, max_length=250)
+    situation: str = Field(..., min_length=2, max_length=400)
+    text: str = Field(..., min_length=5, max_length=600)
 
 class FriendSolutionRequest(FriendMonthlyBaseRequest):
     goal: GoalType = Field(default="resolve")
@@ -69,6 +77,7 @@ class FriendSolutionResponse(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     goal: GoalType = Field(..., description="요청 목표")
     top_strategy: str = Field(..., min_length=5, max_length=200, description="핵심 전략 한 줄")
+    direction_suggestion: str = Field(default="", max_length=120, description="관계 방향성 제안 한 줄")
     actions: List[ActionItem] = Field(..., min_length=1, max_length=6)
     message_templates: List[MessageTemplate] = Field(default_factory=list, max_length=5)
     risks: List[str] = Field(default_factory=list, max_length=8, description="부작용/주의")


### PR DESCRIPTION
## 📌 관계 요약/솔루션 응답 스키마 확장

### 📝 작업 내용
- 관계 요약 결과에 UI 매핑용 필드 추가  
  - `period_label`, `relationship_status_percent`, `relationship_status_label`, `meeting_continuity`, `post_meeting_satisfaction`, `emotion_pattern`, `gift_balance`, `initiative_balance`
- 관계 솔루션 결과에 `direction_suggestion` 필드 추가
- 솔루션 출력이 사진처럼 길게 나오도록 길이 제한 상향  
  - `ActionItem.description` 800  
  - `MessageTemplate.situation` 400  
  - `MessageTemplate.text` 600
- 프롬프트 가이드 강화  
  - action/메시지 템플릿을 더 길고 구체적으로 작성하도록 유도

### ✅ 체크리스트
- [x] 불필요한 주석/코드를 제거
- [x] 로컬 환경에서 정상 동작