### PR TITLE
feat : best-worst friend prompt implement

### DIFF
--- a/src/pipeline/generate_best_worst.py
+++ b/src/pipeline/generate_best_worst.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import json, httpx
+from pathlib import Path
+from typing import Any, Dict
+from dataclasses import asdict, is_dataclass
+
+from src.config.settings import settings
+
+PROMPT_PATH = Path(__file__).resolve().parents[1] / "prompts" / "friend_best_worst_v1.md"
+
+def _load_prompt() -> str:
+    return PROMPT_PATH.read_text(encoding="utf-8")
+
+def _to_payload(obj: Any) -> Dict[str, Any]:
+    if is_dataclass(obj):
+        return asdict(obj)
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    if isinstance(obj, dict):
+        return obj
+    raise TypeError(f"Unsupported payload type: {type(obj)}")
+
+async def call_llm_best_worst(ctx: Dict[str, Any]) -> str:
+    system_prompt = _load_prompt()
+    payload = _to_payload(ctx)
+    user_content = json.dumps(payload, ensure_ascii=False)
+
+    # url = f"{settings.LLM_BASE_URL.rstrip('/')}/chat/completions"
+    url = f"{settings.LLM_BASE_URL.rstrip('/')}/api/chat"
+    body: Dict[str, Any] = {
+        "model": settings.LLM_MODEL,
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content}
+        ]
+    }
+
+    async with httpx.AsyncClient(timeout=settings.LLM_TIMEOUT_SEC) as client:
+        resp = await client.post(url, json=body)
+        resp.raise_for_status()
+        data = resp.json()
+    return data["message"]["content"]

--- a/src/pipeline/generate_best_worst.py
+++ b/src/pipeline/generate_best_worst.py
@@ -25,7 +25,6 @@ async def call_llm_best_worst(ctx: Dict[str, Any]) -> str:
     payload = _to_payload(ctx)
     user_content = json.dumps(payload, ensure_ascii=False)
 
-    # url = f"{settings.LLM_BASE_URL.rstrip('/')}/chat/completions"
     url = f"{settings.LLM_BASE_URL.rstrip('/')}/api/chat"
     body: Dict[str, Any] = {
         "model": settings.LLM_MODEL,

--- a/src/pipeline/postprocess.py
+++ b/src/pipeline/postprocess.py
@@ -4,7 +4,7 @@ import json, re
 from typing import Any, Dict
 from pydantic import ValidationError
 
-from src.schemas.relationship import FriendSummaryResponse, FriendSolutionResponse, SettlementResponse
+from src.schemas.relationship import FriendSummaryResponse, FriendSolutionResponse, SettlementResponse, BestWorstResponse
 
 def _extract_json_object(text: str) -> str:
     text = (text or "").strip()
@@ -85,3 +85,13 @@ def parse_settlement(raw: str) -> SettlementResponse:
         repaired = _basic_repair(json_text)
         data2: Dict[str, Any] = json.loads(repaired)
         return SettlementResponse.model_validate(data2)
+
+def parse_best_worst(raw: str) -> BestWorstResponse:
+    json_text = _extract_json_object(raw)
+    try:
+        data: Dict[str, Any] = json.loads(json_text)
+        return BestWorstResponse.model_validate(data)
+    except (json.JSONDecodeError, ValidationError):
+        repaired = _basic_repair(json_text)
+        data2: Dict[str, Any] = json.loads(repaired)
+        return BestWorstResponse.model_validate(data2)

--- a/src/schemas/relationship.py
+++ b/src/schemas/relationship.py
@@ -130,5 +130,5 @@ class BestWorstItem(BaseModel):
 class BestWorstResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
     version: str = Field(default="v1-friend-best-worst")
-    best_list: List[BestWorstItem] = Field(..., min_length=1, max_length=5)
-    worst_list: List[BestWorstItem] = Field(..., min_length=1, max_length=5)
+    best_list: List[BestWorstItem] = Field(..., min_length=1)
+    worst_list: List[BestWorstItem] = Field(..., min_length=1)

--- a/src/schemas/relationship.py
+++ b/src/schemas/relationship.py
@@ -106,3 +106,29 @@ class SettlementResponse(BaseModel):
     caution_body: str = Field(..., min_length=20, max_length=1200)
     caution_points: List[str] = Field(..., min_length=1, max_length=5, description="주의/워스트 근거 포인트")
     safety: SafetyResult = Field(default_factory=SafetyResult)
+
+# best/worst
+class BestWorstFriendInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    friend_alias: str = Field(..., min_length=1, max_length=40)
+    summaries: List[SettlementMonthlyText] = Field(..., min_length=1, max_length=12)
+    meetings: int = Field(..., ge=0, le=200, description="만남 횟수")
+    rating_avg: float = Field(..., ge=0, le=5, description="평균 평가 점수(0~5)")
+    gift_given: int = Field(..., ge=0, le=200)
+    gift_received: int = Field(..., ge=0, le=200)
+
+class BestWorstRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    friends: List[BestWorstFriendInput] = Field(..., min_length=1, max_length=100)
+
+class BestWorstItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    friend_alias: str = Field(..., min_length=1, max_length=40)
+    reason: str = Field(..., min_length=5, max_length=300)
+    suggestion: str = Field(..., min_length=5, max_length=120)
+
+class BestWorstResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    version: str = Field(default="v1-friend-best-worst")
+    best_list: List[BestWorstItem] = Field(..., min_length=1, max_length=5)
+    worst_list: List[BestWorstItem] = Field(..., min_length=1, max_length=5)


### PR DESCRIPTION
## 📌 best, worst 프롬프트 생성


### 📝 작업 내용
- 분기 정산 best, worst api 분리
- postprocess 추가
- relationship 분기 추가


### ✅ 체크리스트
- [x] 불필요한 주석/코드를 제거
- [x] 로컬 환경에서 정상 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 변경 요약
친구 관계 분석에 Best/Worst 추천 기능을 추가했습니다. LLM 호출·후처리·스키마·API 엔드포인트를 도입해 최고/최악 친구 판별과 개선 제안을 반환합니다.

### 주요 변경점
- src/pipeline/generate_best_worst.py 추가: LLM 호출 함수 call_llm_best_worst 구현 (prompts/friend_best_worst_v1.md 사용, /api/chat 호출)
- src/pipeline/postprocess.py 확장: parse_best_worst(raw) 추가로 LLM 응답 추출·복구·검증 로직 적용
- src/schemas/relationship.py에 BestWorst 관련 모델 4종 추가 (BestWorstFriendInput, BestWorstRequest, BestWorstItem, BestWorstResponse)
- BestWorstRequest에 친구 별칭 중복 검사 필드 검증자 추가(중복 시 422 유도)
- src/serving/api.py에 /best-worst 엔드포인트 추가: 기존 패턴과 동일하게 호출, 후처리, 에러 핸들링 적용
- 불필요 주석/코드 정리 및 친구 리스트 길이 제약 조정(최대 길이 변경/삭제)

### 주의/리스크
- LLM 출력의 JSON 형식 문제(파싱/검증 실패)에 대비한 복구 로직은 있으나 다양한 응답 케이스에 대한 추가 테스트 필요
- 프롬프트 품질(prompts/friend_best_worst_v1.md)과 모델 동작에 따른 결과 민감도 확인 필요

### 다음 액션
- prompts/friend_best_worst_v1.md 검토 및 개선
- Best/Worst 엔드포인트 통합/엣지케이스 테스트 수행 (중복·경계값 포함)
- 배포 전 로깅/모니터링 검증 (LLM 오류/타임아웃 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->